### PR TITLE
Make aggregate_by_date_span() more flexible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: waclr
 Type: Package
 Title: A Collection of Tools to Help at the Wolfson Atmospheric Chemistry 
     Laboratories (WACL)
-Version: 0.1.32
+Version: 0.1.33
 Date: 2019-04-17
 Authors@R: person("Stuart K.", "Grange", email = "stuart.grange@york.ac.uk", 
     role = c("cre", "aut"), comment = c(ORCID = "0000-0003-4093-3596"))

--- a/R/aggregate_by_date_span.R
+++ b/R/aggregate_by_date_span.R
@@ -27,11 +27,11 @@
 #' }
 #'  
 #' @export
-aggregate_by_date_span <- function(df, df_met, warn = TRUE, progress = "none",...) {
+aggregate_by_date_span <- function(df, df_met, warn = TRUE,...) {
   
-  # Do row-wise
-  plyr::adply(df, 1, function(x) 
-    aggregate_by_date_span_worker(x, df_met, warn), .progress = progress,...)
+  df %>% split(seq(nrow(df))) %>% 
+    purrr::map_df(aggregate_by_date_span_worker,df_met = df_met, warn = warn,...)
+  
   
 }
 
@@ -41,6 +41,15 @@ aggregate_by_date_span_worker <- function(df, df_met, warn,...) {
   # Get dates
   date_start <- df$date_start[1]
   date_end <- df$date_end[1]
+  
+  if(is.na(date_start) | is.na(date_end)){
+    if(warn){
+      warning(stringr::str_c("Skipping row: ", row.names(df)), call. = FALSE)
+      return(NULL)
+    }else{
+      return(NULL)
+    }
+  }
   
   # Filter met by dates
   df_met_filter <- df_met[df_met$date >= date_start & df_met$date <= date_end, ]

--- a/R/aggregate_by_date_span.R
+++ b/R/aggregate_by_date_span.R
@@ -10,7 +10,7 @@
 #' 
 #' @param warn Should the function give warnings? 
 #' 
-#' @param progress Type of progress bar. Supply "time" for progress bar. 
+#' @param progress Depreciated as purrr::map_Df is used over plyr::adply
 #' 
 #' @param ... Additional arguments to pass to openair::timeAverage
 #' 
@@ -27,16 +27,19 @@
 #' }
 #'  
 #' @export
-aggregate_by_date_span <- function(df, df_met, warn = TRUE,...) {
+aggregate_by_date_span <- function(df, df_met, warn = TRUE, progress = NULL, ...) {
   
-  df %>% split(seq(nrow(df))) %>% 
+  if(!is.null(progress)) # warning in the case of backwards compatibility
+    warning("progress argument is depreciated")
+  
+  df %>% split(seq(nrow(df))) %>% # convert data.frame to a list of its rows
     purrr::map_df(aggregate_by_date_span_worker,df_met = df_met, warn = warn,...)
   
   
 }
 
 
-aggregate_by_date_span_worker <- function(df, df_met, warn,...) {
+aggregate_by_date_span_worker <- function(df, df_met, warn, ...) {
   
   # Get dates
   date_start <- df$date_start[1]

--- a/R/aggregate_by_date_span.R
+++ b/R/aggregate_by_date_span.R
@@ -12,6 +12,8 @@
 #' 
 #' @param progress Type of progress bar. Supply "time" for progress bar. 
 #' 
+#' @param ... Additional arguments to pass to openair::timeAverage
+#' 
 #' @author Will Drysdale and Stuart K. Grange
 #' 
 #' @return Data frame. 
@@ -25,16 +27,16 @@
 #' }
 #'  
 #' @export
-aggregate_by_date_span <- function(df, df_met, warn = TRUE, progress = "none") {
+aggregate_by_date_span <- function(df, df_met, warn = TRUE, progress = "none",...) {
   
   # Do row-wise
   plyr::adply(df, 1, function(x) 
-    aggregate_by_date_span_worker(x, df_met, warn), .progress = progress)
+    aggregate_by_date_span_worker(x, df_met, warn), .progress = progress,...)
   
 }
 
 
-aggregate_by_date_span_worker <- function(df, df_met, warn) {
+aggregate_by_date_span_worker <- function(df, df_met, warn,...) {
   
   # Get dates
   date_start <- df$date_start[1]
@@ -47,7 +49,7 @@ aggregate_by_date_span_worker <- function(df, df_met, warn) {
   if (nrow(df_met_filter) >= 1) {
     
     # Do
-    df_met_filter_agg <- openair::timeAverage(df_met_filter, avg.time = "year")
+    df_met_filter_agg <- openair::timeAverage(df_met_filter, avg.time = "year",...)
     
   } else {
     

--- a/man/aggregate_by_date_span.Rd
+++ b/man/aggregate_by_date_span.Rd
@@ -4,7 +4,7 @@
 \alias{aggregate_by_date_span}
 \title{Aggregate meteorological data from date span.}
 \usage{
-aggregate_by_date_span(df, df_met, warn = TRUE, progress = "none")
+aggregate_by_date_span(df, df_met, warn = TRUE, progress = NULL, ...)
 }
 \arguments{
 \item{df}{Data frame containing span range.}
@@ -13,7 +13,9 @@ aggregate_by_date_span(df, df_met, warn = TRUE, progress = "none")
 
 \item{warn}{Should the function give warnings?}
 
-\item{progress}{Type of progress bar. Supply "time" for progress bar.}
+\item{progress}{Depreciated as purrr::map_Df is used over plyr::adply}
+
+\item{...}{Additional arguments to pass to openair::timeAverage}
 }
 \value{
 Data frame.


### PR DESCRIPTION
Add `...` argument to `aggregate_by_date_span` and pass additional arguments to `openair::timeAverage()`.
No longer limited to calculating the mean as the timeAverage statistic.

Vectorization changed from `plyr::adply()` to `purr::map_df()` as adply was throwing errors with `...`